### PR TITLE
Deploy from Github

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: amondnet/vercel-action@v19.0.1
-        id: now-deployment
+        id: vercel-deployment
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -16,4 +16,4 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
       - name: preview-url
         run: |
-          echo ${{ steps.now-deployment.outputs.preview-url }}
+          echo ${{ steps.vercel-deployment.outputs.preview-url }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,24 @@
+
+name: deploy production
+on:
+  push:
+    branches:
+      - master
+      - release_**
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: amondnet/vercel-action@v19.0.1
+        id: vercel-deployment
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          vercel-args: --prod
+      - name: preview-url
+        run: |
+          echo ${{ steps.vercel-deployment.outputs.preview-url }}

--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -1,7 +1,7 @@
 name: Mirroring
 
 on: [push]
-    
+
 jobs:
   to_github:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
because there are 100 deployment limits on what free account can do. while Vercel ridiculously triggers so many deployments.

also, we want to customize when the deployment triggers, ex:
 for production, we want to sequence between the deployment and API tests.